### PR TITLE
Updates for Django 4.2

### DIFF
--- a/graphene_django/__init__.py
+++ b/graphene_django/__init__.py
@@ -1,7 +1,7 @@
 from .fields import DjangoConnectionField, DjangoListField
 from .types import DjangoObjectType
 
-__version__ = "2.15.0"
+__version__ = "2.15.0.post1"
 
 __all__ = [
     "__version__",

--- a/graphene_django/management/commands/graphql_schema.py
+++ b/graphene_django/management/commands/graphql_schema.py
@@ -48,7 +48,7 @@ class CommandArguments(BaseCommand):
 class Command(CommandArguments):
     help = "Dump Graphene schema as a JSON or GraphQL file"
     can_import_settings = True
-    requires_system_checks = False
+    requires_system_checks = []
 
     def save_json_file(self, out, schema_dict, indent):
         with open(out, "w") as outfile:

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 CHOICES = ((1, "this"), (2, _("that")))
 

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import pytest
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from py.test import raises
 
 import graphene

--- a/graphene_django/utils/utils.py
+++ b/graphene_django/utils/utils.py
@@ -3,7 +3,7 @@ import inspect
 import six
 from django.db import connection, models, transaction
 from django.db.models.manager import Manager
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import Promise
 
 from graphene.utils.str_converters import to_camel_case
@@ -26,7 +26,7 @@ def isiterable(value):
 
 def _camelize_django_str(s):
     if isinstance(s, Promise):
-        s = force_text(s)
+        s = force_str(s)
     return to_camel_case(s) if isinstance(s, six.string_types) else s
 
 


### PR DESCRIPTION
# Updates for Django 4.2
## Django 4.0.10
* [Django 4.0 deprecations](https://docs.djangoproject.com/en/5.0/internals/deprecation/#deprecation-removed-in-4-0):
* See the [Django 3.0 release notes](https://docs.djangoproject.com/en/5.0/releases/3.0/#deprecated-features-3-0) for more details on these changes.

- [x] **django.utils.encoding.force_text()** and **smart_text()** will be removed.  The aliases are  force_str() and smart_str().
- [x] **django.utils.http.urlquote()**, **urlquote_plus()**, **urlunquote()**, and **urlunquote_plus()** will be removed.
- [x] **django.utils.translation.ugettext()**, **ugettext_lazy()**, **ugettext_noop()**, **ungettext()**, and **ungettext_lazy()** will be removed.
- [x] **django.views.i18n.set_language()** will no longer set the user language in **request.session** (key **django.utils.translation.LANGUAGE_SESSION_KEY**). 
- [x] **alias=None** will be required in the signature of **django.db.models.Expression.get_group_by_cols()** subclasses.
- [x] **django.utils.text.unescape_entities()** will be removed.
- [x] **django.utils.http.is_safe_url()** will be removed.

* See the [Django 3.1 release notes](https://docs.djangoproject.com/en/5.0/releases/3.1/#deprecated-features-3-1) for more details on these changes.
- [x] **The PASSWORD_RESET_TIMEOUT_DAYS** setting will be removed.
- [x] The undocumented usage of the **isnull** lookup with non-boolean values as the right-hand side will no longer be allowed.
- [x] The **django.db.models.query_utils.InvalidQuery** exception class will be removed.
- [x] The **django-admin.py** entry point will be removed.
- [x] Support for the pre-Django 3.1 encoding format of cookies values used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] The **providing_args** argument for **django.dispatch.Signal** will be removed.
- [x] The **length** argument for **django.utils.crypto.get_random_string()** will be required.
- [x] The model **NullBooleanField** will be removed. A stub field will remain for compatibility with historical migrations. 
- [x] The model **django.contrib.postgres.fields.JSONField** will be removed. A stub field will remain for compatibility with historical migrations.
- [x] **django.contrib.postgres.forms.JSONField**, **django.contrib.postgres.fields.jsonb.KeyTransform**, and **django.contrib.postgres.fields.jsonb.KeyTextTransform** will be removed.
- [x] The **DEFAULT_HASHING_ALGORITHM** transitional setting will be removed.
- [x] Support for passing raw column aliases to **QuerySet.order_by()** will be removed.
- [x] **django.conf.urls.url()** will be removed.  It's an alias of **django.urls.re_path()**.
- [x] The **get_response** argument for **django.utils.deprecation.MiddlewareMixin.__init__()** will be required and won’t accept **None**.
- [x] The **list** message for **ModelMultipleChoiceField** will be removed.
- [x] The **HttpRequest.is_ajax()** method will be removed.
- [x] The **{% ifequal %}** and **{% ifnotequal %}** template tags will be removed.

### pre-Django 3.1 SHA-1
- [x] Support for the pre-Django 3.1 password reset tokens in the admin site (that use the SHA-1 hashing algorithm) will be removed.
- [x] Support for the pre-Django 3.1 encoding format of sessions will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.Signer** signatures (encoded with the SHA-1 algorithm) will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.dumps()** signatures (encoded with the SHA-1 algorithm) in **django.core.signing.loads()** will be removed.
- [x] Support for the pre-Django 3.1 user sessions (that use the SHA-1 algorithm) will be removed.

## Django 4.1.13
See the [Django 3.2 release notes](https://docs.djangoproject.com/en/5.0/releases/3.2/#deprecated-features-3-2) for more details on these changes.

- [x] Support for assigning objects which don’t support creating deep copies with **copy.deepcopy()** to class attributes in **TestCase.setUpTestData()** will be removed.
- [x] The **whitelist** argument and **domain_whitelist** attribute of **django.core.validators.EmailValidator** will be removed.
- [x] **TransactionTestCase.assertQuerysetEqual()** will no longer automatically call **repr()** on a queryset when compared to string values.
- [x] Support for the pre-Django 3.2 format of messages used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] **BaseCommand.requires_system_checks** won’t support boolean values. Use '__all__' instead of True, and [] (an empty list) instead of False.
- [x] **django.core.cache.backends.memcached.MemcachedCache** will be removed.
- [x] The **default_app_config** module variable will be removed. 
